### PR TITLE
wasmtime v11.0.1 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
     folder: crates/wasi-http/wasi-http
 
 build:
-  number: 0
+  number: 1
   skip: True # [linux and (s390x or ppc64le)]
   skip: True  # [win and (rust_compiler == 'rust-gnu')]
   missing_dso_whitelist:


### PR DESCRIPTION
wasmtime v11.0.1 rebuild :snowflake:

**Destination channel:** Snowflake 

### Links

- [PKG-6210](https://anaconda.atlassian.net/browse/PKG-6210) 

### Explanation of changes:
  - Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.


[PKG-6210]: https://anaconda.atlassian.net/browse/PKG-6210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ