### PR TITLE
[PKG-6947] Update to 29.0.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 cargo build --release
 
-echo %CMAKE_GENERATOR%
+SET CMAKE_GENERATOR = "Visual Studio 16 2019"
 
 cmake -G"%CMAKE_GENERATOR%" -S crates/c-api -B target/c-api --install-prefix "%SRC_DIR%/artifacts"
 cmake -G"%CMAKE_GENERATOR%" --build target/c-api

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,7 @@
 cargo build --release
 
+echo %CMAKE_GENERATOR%
+
 cmake -G"%CMAKE_GENERATOR%" -S crates/c-api -B target/c-api --install-prefix "%SRC_DIR%/artifacts"
 cmake -G"%CMAKE_GENERATOR%" --build target/c-api
 cmake -G"%CMAKE_GENERATOR%" --install target/c-api

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,10 +1,8 @@
 cargo build --release
 
-set CMAKE_GENERATOR="Visual Studio 16 2019"
-
-cmake -G"%CMAKE_GENERATOR%" -S crates/c-api -B target/c-api --install-prefix "%SRC_DIR%/artifacts"
-cmake -G"%CMAKE_GENERATOR%" --build target/c-api
-cmake -G"%CMAKE_GENERATOR%" --install target/c-api
+cmake -G "Visual Studio 16 2019" -S crates/c-api -B target/c-api --install-prefix "%SRC_DIR%/artifacts"
+cmake --build target/c-api
+cmake --install target/c-api
 
 copy %SRC_DIR%\target\release\wasmtime.exe %LIBRARY_BIN%
 copy %SRC_DIR%\target\release\libwasmtime_cli.rlib  %LIBRARY_LIB%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,8 @@
 cargo build --release
 
-echo "Building C libraries..."
-cmake -G"%CMAKE_GENERATOR%" -S crates\c-api -B target\c-api --install-prefix "%SRC_DIR%\artifacts"
-cmake -G"%CMAKE_GENERATOR%" --build target\c-api
-cmake -G"%CMAKE_GENERATOR%" --install target\c-api
+cmake -G"%CMAKE_GENERATOR%" -S crates/c-api -B target/c-api --install-prefix "%SRC_DIR%/artifacts"
+cmake -G"%CMAKE_GENERATOR%" --build target/c-api
+cmake -G"%CMAKE_GENERATOR%" --install target/c-api
 
 copy %SRC_DIR%\target\release\wasmtime.exe %LIBRARY_BIN%
 copy %SRC_DIR%\target\release\libwasmtime_cli.rlib  %LIBRARY_LIB%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 cargo build --release
 
-SET CMAKE_GENERATOR = "Visual Studio 16 2019"
+set CMAKE_GENERATOR="Visual Studio 16 2019"
 
 cmake -G"%CMAKE_GENERATOR%" -S crates/c-api -B target/c-api --install-prefix "%SRC_DIR%/artifacts"
 cmake -G"%CMAKE_GENERATOR%" --build target/c-api

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,11 @@
 cargo build --release
-cargo build --release --manifest-path crates\c-api\Cargo.toml
+
+echo "Building C libraries..."
+cmake -S crates\c-api -B target\c-api --install-prefix "$(pwd)\artifacts"
+cmake --build target\c-api
+cmake --install target\c-api
 
 copy %SRC_DIR%\target\release\wasmtime.exe %LIBRARY_BIN%
-copy %SRC_DIR%\target\release\wasmtime.dll  %LIBRARY_BIN%
-copy %SRC_DIR%\target\release\wasmtime.dll.lib  %LIBRARY_LIB%
 copy %SRC_DIR%\target\release\libwasmtime_cli.rlib  %LIBRARY_LIB%
+copy %SRC_DIR%\artifacts\lib\wasmtime.dll  %LIBRARY_BIN%
+copy %SRC_DIR%\artifacts\lib\wasmtime.dll.lib  %LIBRARY_LIB%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,5 +6,4 @@ cmake --install target/c-api
 
 copy %SRC_DIR%\target\release\wasmtime.exe %LIBRARY_BIN%
 copy %SRC_DIR%\target\release\libwasmtime_cli.rlib  %LIBRARY_LIB%
-copy %SRC_DIR%\artifacts\lib\wasmtime.dll  %LIBRARY_BIN%
-copy %SRC_DIR%\artifacts\lib\wasmtime.dll.a  %LIBRARY_LIB%
+copy %SRC_DIR%\artifacts\lib\wasmtime.dll  %LIBRARY_LIB%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 cargo build --release
 
 echo "Building C libraries..."
-cmake -S crates\c-api -B target\c-api --install-prefix "$(pwd)\artifacts"
+cmake -S crates\c-api -B target\c-api --install-prefix "%SRC_DIR%\artifacts"
 cmake --build target\c-api
 cmake --install target\c-api
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,11 +1,11 @@
 cargo build --release
 
 echo "Building C libraries..."
-cmake -S crates\c-api -B target\c-api --install-prefix "%SRC_DIR%\artifacts"
+cmake -G"%CMAKE_GENERATOR%" -S crates\c-api -B target\c-api --install-prefix "%SRC_DIR%\artifacts"
 cmake --build target\c-api
 cmake --install target\c-api
 
 copy %SRC_DIR%\target\release\wasmtime.exe %LIBRARY_BIN%
 copy %SRC_DIR%\target\release\libwasmtime_cli.rlib  %LIBRARY_LIB%
 copy %SRC_DIR%\artifacts\lib\wasmtime.dll  %LIBRARY_BIN%
-copy %SRC_DIR%\artifacts\lib\wasmtime.dll.lib  %LIBRARY_LIB%
+copy %SRC_DIR%\artifacts\lib\wasmtime.dll.a  %LIBRARY_LIB%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,4 +6,6 @@ cmake --install target/c-api
 
 copy %SRC_DIR%\target\release\wasmtime.exe %LIBRARY_BIN%
 copy %SRC_DIR%\target\release\libwasmtime_cli.rlib  %LIBRARY_LIB%
-copy %SRC_DIR%\artifacts\lib\wasmtime.dll  %LIBRARY_LIB%
+copy %SRC_DIR%\artifacts\lib\wasmtime.dll  %LIBRARY_BIN%
+copy %SRC_DIR%\artifacts\lib\wasmtime.dll.lib  %LIBRARY_LIB%
+

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,8 +2,8 @@ cargo build --release
 
 echo "Building C libraries..."
 cmake -G"%CMAKE_GENERATOR%" -S crates\c-api -B target\c-api --install-prefix "%SRC_DIR%\artifacts"
-cmake --build target\c-api
-cmake --install target\c-api
+cmake -G"%CMAKE_GENERATOR%" --build target\c-api
+cmake -G"%CMAKE_GENERATOR%" --install target\c-api
 
 copy %SRC_DIR%\target\release\wasmtime.exe %LIBRARY_BIN%
 copy %SRC_DIR%\target\release\libwasmtime_cli.rlib  %LIBRARY_LIB%

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
+echo "Building binaries..."
 cargo build --release
-cargo build --release --manifest-path crates/c-api/Cargo.toml
+
+echo "Building C libraries..."
+cmake -S crates/c-api -B target/c-api --install-prefix "$(pwd)/artifacts"
+cmake --build target/c-api
+cmake --install target/c-api
+
 
 mkdir -p ${PREFIX}/bin
 mkdir -p ${PREFIX}/lib
 
 cp ${SRC_DIR}/target/release/wasmtime ${PREFIX}/bin/
-cp ${SRC_DIR}/target/release/libwasmtime_c_api.rlib ${PREFIX}/lib/
-cp ${SRC_DIR}/target/release/libwasmtime_cli.rlib ${PREFIX}/lib/
+cp ${SRC_DIR}/artifacts/lib/libwasmtime$SHLIB_EXT ${PREFIX}/lib/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,8 +6,5 @@ mkdir -p ${PREFIX}/bin
 mkdir -p ${PREFIX}/lib
 
 cp ${SRC_DIR}/target/release/wasmtime ${PREFIX}/bin/
-cp ${SRC_DIR}/target/release/wasmtime.d ${PREFIX}/bin/
 cp ${SRC_DIR}/target/release/libwasmtime_c_api.rlib ${PREFIX}/lib/
-cp ${SRC_DIR}/target/release/libwasmtime_c_api.d ${PREFIX}/lib/
 cp ${SRC_DIR}/target/release/libwasmtime_cli.rlib ${PREFIX}/lib/
-cp ${SRC_DIR}/target/release/libwasmtime_cli.d ${PREFIX}/lib/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,6 +6,8 @@ mkdir -p ${PREFIX}/bin
 mkdir -p ${PREFIX}/lib
 
 cp ${SRC_DIR}/target/release/wasmtime ${PREFIX}/bin/
-cp ${SRC_DIR}/target/release/libwasmtime$SHLIB_EXT ${PREFIX}/lib/
+cp ${SRC_DIR}/target/release/wasmtime.d ${PREFIX}/bin/
+cp ${SRC_DIR}/target/release/libwasmtime_c_api.rlib ${PREFIX}/lib/
+cp ${SRC_DIR}/target/release/libwasmtime_c_api.d ${PREFIX}/lib/
 cp ${SRC_DIR}/target/release/libwasmtime_cli.rlib ${PREFIX}/lib/
-
+cp ${SRC_DIR}/target/release/libwasmtime_cli.d ${PREFIX}/lib/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,6 @@ cmake -S crates/c-api -B target/c-api --install-prefix "${SRC_DIR}/artifacts"
 cmake --build target/c-api
 cmake --install target/c-api
 
-
 mkdir -p ${PREFIX}/bin
 mkdir -p ${PREFIX}/lib
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,6 +11,17 @@ cmake --install target/c-api
 mkdir -p ${PREFIX}/bin
 mkdir -p ${PREFIX}/lib
 
+ls ${SRC_DIR}/artifacts/lib
+ls ${SRC_DIR}/target/release
+
+UNAME_S=$(uname -s)
+case "$UNAME_S" in
+  Darwin*)
+    LIBDIR="lib";;
+  *)
+    LIBDIR="lib64";;
+esac
+
 cp ${SRC_DIR}/target/release/wasmtime ${PREFIX}/bin/
-cp ${SRC_DIR}/artifacts/lib/libwasmtime$SHLIB_EXT ${PREFIX}/lib/
+cp ${SRC_DIR}/artifacts/${LIBDIR}/libwasmtime$SHLIB_EXT ${PREFIX}/lib/
 cp ${SRC_DIR}/target/release/libwasmtime_cli.rlib ${PREFIX}/lib/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,7 @@ echo "Building binaries..."
 cargo build --release
 
 echo "Building C libraries..."
-cmake -S crates/c-api -B target/c-api --install-prefix "$(pwd)/artifacts"
+cmake -S crates/c-api -B target/c-api --install-prefix "${SRC_DIR}/artifacts"
 cmake --build target/c-api
 cmake --install target/c-api
 
@@ -13,3 +13,4 @@ mkdir -p ${PREFIX}/lib
 
 cp ${SRC_DIR}/target/release/wasmtime ${PREFIX}/bin/
 cp ${SRC_DIR}/artifacts/lib/libwasmtime$SHLIB_EXT ${PREFIX}/lib/
+cp ${SRC_DIR}/target/release/libwasmtime_cli.rlib ${PREFIX}/lib/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,9 +11,6 @@ cmake --install target/c-api
 mkdir -p ${PREFIX}/bin
 mkdir -p ${PREFIX}/lib
 
-ls ${SRC_DIR}/artifacts/lib
-ls ${SRC_DIR}/target/release
-
 UNAME_S=$(uname -s)
 case "$UNAME_S" in
   Darwin*)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ test:
     - wasmtime --help
     - test -f ${PREFIX}/lib/libwasmtime.so      # [linux]
     - test -f ${PREFIX}/lib/libwasmtime.dylib   # [osx]
+    - if not exist %PREFIX%\Library\bin\wasmtime.dll exit 1    # [win]
+    - if not exist %PREFIX%\Library\lib\wasmtime.dll.lib exit 1    # [win]
 
 about:
   home: https://github.com/bytecodealliance/wasmtime

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "wasmtime" %}
-{% set version = "11.0.1" %}
+{% set version = "29.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,26 +7,10 @@ package:
 
 source:
   - url: https://github.com/bytecodealliance/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 681d03d9ebf63697edf8b6c7df460aca6ecc0058106b07f8ac049a0b2a07308b
-
-  - url: https://github.com/WebAssembly/WASI/archive/0ba0c5e2e37625ca5a6d3e4255a998dfaa3efc52.tar.gz
-    sha256: 1a0dce1333fa5d588a09d81acd63a8eb1e13296768f24cb348ceffaf5e6f51fd
-    folder: crates/wasi-common/WASI
-
-  - url: https://github.com/WebAssembly/wasi-crypto/archive/67d9821f2763f4626a97c70c411ccb92a2047712.tar.gz
-    sha256: 49ebe4479ffefe191208b9bc7ab9588fc9ce896ef43221d0d241789a71224bd1
-    folder: crates/wasi-crypto/spec
-
-  - url: https://github.com/WebAssembly/wasi-nn/archive/8adc5b9b3bb8f885d44f55b464718e24af892c94.tar.gz
-    sha256: 65748477f6d834c2d41de6bbe773254c395e4ddeae3461f84997c58dbf6276be
-    folder: crates/wasi-nn/spec
-
-  - url: https://github.com/WebAssembly/wasi-http/archive/1c95bc21dbd193b046e4232d063a82c8b5ba7994.tar.gz
-    sha256: 8d0a31a4265f610627a86aa7766d4f511b23a19f9c06d6c9febbf29f02cb4f64
-    folder: crates/wasi-http/wasi-http
+    sha256: 0b3e2823b5a9155764bd1a5cba2f0e9f3069c407a5c329cce1f58dde6e67cd9d
 
 build:
-  number: 1
+  number: 0
   skip: True # [linux and (s390x or ppc64le)]
   skip: True  # [win and (rust_compiler == 'rust-gnu')]
   missing_dso_whitelist:
@@ -40,7 +24,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('rust') }} 
+    - {{ compiler('rust') }}
+    - cmake
 
   run:
     - libgcc-ng                  # [linux]
@@ -48,10 +33,9 @@ requirements:
 test:
   commands:
     - wasmtime --help
-    - test -f ${PREFIX}/lib/libwasmtime.so      # [linux]
-    - test -f ${PREFIX}/lib/libwasmtime.dylib   # [osx]
-    - if not exist %PREFIX%\Library\bin\wasmtime.dll exit 1    # [win]
-    - if not exist %PREFIX%\Library\lib\wasmtime.dll.lib exit 1    # [win]
+    #- cargo test -f ${PREFIX}/lib/libwasmtime_cli.rlib      # [unix]
+    #- if not exist %PREFIX%\Library\bin\wasmtime.dll exit 1    # [win]
+    #- if not exist %PREFIX%\Library\lib\wasmtime.dll.lib exit 1    # [win]
 
 about:
   home: https://github.com/bytecodealliance/wasmtime

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - cmake
-    - make  # [linux]
 
   run:
     - libgcc-ng                  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - cmake
+    - make  # [linux]
 
   run:
     - libgcc-ng                  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,9 +33,8 @@ requirements:
 test:
   commands:
     - wasmtime --help
-    #- cargo test -f ${PREFIX}/lib/libwasmtime_cli.rlib      # [unix]
-    #- if not exist %PREFIX%\Library\bin\wasmtime.dll exit 1    # [win]
-    #- if not exist %PREFIX%\Library\lib\wasmtime.dll.lib exit 1    # [win]
+    - test -f ${PREFIX}/lib/libwasmtime.so      # [linux]
+    - test -f ${PREFIX}/lib/libwasmtime.dylib   # [osx]
 
 about:
   home: https://github.com/bytecodealliance/wasmtime


### PR DESCRIPTION
wasmtime 29.0.0

**Destination channel:** defaults

### Links

- [PKG-6947] 
- [Upstream repository](https://github.com/bytecodealliance/wasmtime)
- [Upstream changelog/diff]()

### Explanation of changes:

- Removed former submodules that are now included in the source.
- Updated build scripts to generate dynamic libraries.


[PKG-6947]: https://anaconda.atlassian.net/browse/PKG-6947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ